### PR TITLE
Added documentation, throw exception for unsupported Nurbs curve

### DIFF
--- a/svgPort/Illustrator.csproj
+++ b/svgPort/Illustrator.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Illustrator.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/svgPort/NurbsExportAsSVG.dyn
+++ b/svgPort/NurbsExportAsSVG.dyn
@@ -1,25 +1,25 @@
-<Workspace Version="0.8.3.2684" X="67.94107206967" Y="56.6707312831376" zoom="0.597081317502783" Name="Home" Description="" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
+<Workspace Version="0.8.3.2752" X="153.274405403003" Y="123.337397949804" zoom="0.597081317502783" Name="Home" Description="" RunType="Automatic" RunPeriod="100" HasRunWithoutCrash="True">
   <NamespaceResolutionMap />
   <Elements>
-    <Dynamo.Nodes.DSFunction guid="783bd7e0-abba-4997-9d7e-1e1106fbdaf2" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="692.93021296656" y="-54.9926864079732" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],int">
+    <Dynamo.Nodes.DSFunction guid="783bd7e0-abba-4997-9d7e-1e1106fbdaf2" type="Dynamo.Nodes.DSFunction" nickname="NurbsCurve.ByPoints" x="799.001750421822" y="-51.643058909386" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.NurbsCurve.ByPoints@Autodesk.DesignScript.Geometry.Point[],int">
       <PortInfo index="1" default="True" />
     </Dynamo.Nodes.DSFunction>
     <Dynamo.Nodes.DSFunction guid="aca4f0f8-179c-4c28-a842-b24f8dd1fe94" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="180.572620603618" y="-70.5930828784931" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
       <PortInfo index="0" default="True" />
       <PortInfo index="1" default="True" />
     </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="32a0bb25-830c-4907-bd99-c83bd01ff5ad" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-101.826926942374" y="267.565362995079" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="10;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="32a0bb25-830c-4907-bd99-c83bd01ff5ad" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-101.826926942374" y="267.565362995079" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="100;" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction guid="6ffb8315-8df9-4ddf-8dba-d8408660e360" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="76.0679726313051" y="52.6223372466006" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
       <PortInfo index="0" default="True" />
       <PortInfo index="1" default="True" />
     </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="c79f9eee-f4a9-46fa-a390-4f2250b8de54" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-73.6742041926466" y="85.740194471352" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="5;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="c79f9eee-f4a9-46fa-a390-4f2250b8de54" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="-73.6742041926466" y="85.740194471352" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="50;" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction guid="82151fd9-2c94-445b-84d1-6a7d8d943b44" type="Dynamo.Nodes.DSFunction" nickname="Point.ByCoordinates" x="71.2723943766141" y="182.635317978984" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="ProtoGeometry.dll" function="Autodesk.DesignScript.Geometry.Point.ByCoordinates@double,double">
       <PortInfo index="0" default="True" />
       <PortInfo index="1" default="True" />
     </Dynamo.Nodes.DSFunction>
-    <Dynamo.Nodes.CodeBlockNodeModel guid="358336de-24dd-4308-989b-cc8abfa7af0e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="409.381235574181" y="-27.2596935616716" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="{p1, p2, p3, p4};" ShouldFocus="false" />
-    <Dynamo.Nodes.CodeBlockNodeModel guid="22d79bfd-b5ca-43af-ab17-e4f229483bb6" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="568" y="72" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="2;" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="358336de-24dd-4308-989b-cc8abfa7af0e" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="448.460223057698" y="-48.4740010527238" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" CodeText="{p1, p2, p3, p4};" ShouldFocus="false" />
+    <Dynamo.Nodes.CodeBlockNodeModel guid="22d79bfd-b5ca-43af-ab17-e4f229483bb6" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="655.090314963267" y="86.5150524938778" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="3;" ShouldFocus="false" />
     <Dynamo.Nodes.DSFunction guid="877cef9a-d22e-4be0-9bd0-325409b993fa" type="Dynamo.Nodes.DSFunction" nickname="SVG.export" x="1161.62849432908" y="65.9697257485379" isVisible="true" isUpstreamVisible="true" lacing="Shortest" isSelectedInput="False" assembly="bin\Debug\Illustrator.dll" function="Illustrator.SVG.export@Autodesk.DesignScript.Geometry.Geometry[],string,string" />
     <Dynamo.Nodes.CodeBlockNodeModel guid="1c179593-8b8f-4730-8dc9-24bc62f211ec" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="588.491611256441" y="204.663037862397" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;C:\Users\pratapa.ADS\Documents&quot;;" ShouldFocus="false" />
     <Dynamo.Nodes.CodeBlockNodeModel guid="15403dcf-e07c-4c89-a7d0-e2b1e0361e5f" type="Dynamo.Nodes.CodeBlockNodeModel" nickname="Code Block" x="980.519275156367" y="366.127153169378" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" CodeText="&quot;test&quot;;" ShouldFocus="false" />
@@ -49,6 +49,6 @@
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="12.553768157959" eyeY="13.3839302062988" eyeZ="9.06230068206787" lookX="-10" lookY="-10" lookZ="-10" upX="0" upY="1" upZ="0" />
+    <Camera Name="Background Preview" eyeX="189.932601928711" eyeY="192.432113647461" eyeZ="189.932601928711" lookX="-189.932601928711" lookY="-189.932601928711" lookZ="-189.932601928711" upX="0" upY="1" upZ="0" />
   </Cameras>
 </Workspace>

--- a/svgPort/svg.cs
+++ b/svgPort/svg.cs
@@ -143,7 +143,24 @@ namespace Illustrator
             maxPt = Point.ByCoordinates(maxX, maxY, maxZ);
         }
 
-        public static void export(Geometry[] geometry, String exportLocation, string fileName)
+
+        /// <summary>
+        /// Exports Dynamo geometry as an SVG File.
+        /// Supported geometry includes Point, Line, Circle, Ellipse, Polygon and NurbsCurve.
+        /// PolyCurve is not supported currently.
+        /// Only NurbsCurve of degree 3 can be converted.
+        /// </summary>
+        /// <param name="geometry">1D list of Geometry</param>
+        /// <param name="exportLocation">Folder location for saving SVG file</param>
+        /// <param name="fileName"></param>
+        /// <param name="units">
+        /// Accepted units are "em", "ex", "px", "pt", "pc", "cm", "mm", "in".
+        /// The default is pixels ("px").
+        /// </param>
+        /// <search>
+        /// export, SVG, Illustrator
+        /// </search>
+        public static void export(Geometry[] geometry, String exportLocation, string fileName, string units = "px")
         {
             Point minPt, maxPt;
             ComputeBoundingBox(geometry, out minPt, out maxPt);
@@ -158,8 +175,8 @@ namespace Illustrator
             //start the svg tag
             file.WriteLine("<svg version='1.1' xmlns='http://www.w3.org/2000/svg' " +
                            "xmlns:xlink='http://www.w3.org/1999/xlink' " +
-                           "x='0px' y='0px' width='" + (maxPt.X - minPt.X) + "px' height='" + (maxPt.Y - minPt.Y) +
-                           "px' viewBox='0 0 " + (maxPt.X - minPt.X) + " " + (maxPt.Y - minPt.Y) + "' xml:space='preserve'> ");
+                           "width='" + (maxPt.X - minPt.X) + units + "' height='" + (maxPt.Y - minPt.Y) +
+                           units + "' viewBox='0 0 " + (maxPt.X - minPt.X) + " " + (maxPt.Y - minPt.Y) + "' xml:space='preserve'> ");
 
 
             //segregate all points
@@ -321,6 +338,8 @@ namespace Illustrator
 
         private static Point[][] DecomposeNurbsCurve(NurbsCurve nurbCurve)
         {
+            if(nurbCurve.Degree != 3)
+                throw  new Exception("Only degree 3 NURBS curves can be exported to SVG");
             var P = nurbCurve.ControlPoints();
             int p = nurbCurve.Degree;
             var U = nurbCurve.Knots();


### PR DESCRIPTION
Added following enhancements:
- Added documentation for `SVG.export` node
- Throwing exception for NURBS curves having degree other than `3`. Only NURBS curves with degree `3` can be converted as SVG format
- Added default argument for units to node. The default value is `px`. Users can now control the units by passing any of the following values to the `units` parameter of the node: 

```
em, ex, px, pt, pc, cm, mm and in
```
